### PR TITLE
Website expansion: multi-page project site with top navigation

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,3 +143,18 @@ pytest
 - `docs/technical_writeup.md` — project objective, dataset, modeling workflow, testing, limitations, and future work.
 - `docs/architecture.md` — current module boundaries, request flow, and saved artifact layout.
 - `docs/presentation_notes.md` — slide-ready content for a short project demo.
+
+## Project Website
+
+The FastAPI app doubles as a multi-page project website. After starting the server, visit:
+
+| Page | Route | Description |
+|------|-------|-------------|
+| Home | `/` | Project overview and navigation |
+| Demo | `/demo` | Live prediction with example inputs |
+| How It Works | `/how-it-works` | Dataset, models, preprocessing |
+| Results | `/results` | Charts, confusion matrices, ROC curves |
+| Architecture | `/architecture` | Code organization and request flows |
+| Presentation | `/presentation` | Slide-style project walkthrough |
+
+A shared top navigation bar links all pages together, with an external link to the GitHub repository.

--- a/docs/CODEX_WEBSITE_EXPANSION_PLAN.md
+++ b/docs/CODEX_WEBSITE_EXPANSION_PLAN.md
@@ -1,0 +1,366 @@
+# Codex Website Expansion Plan: Multi-Page Project Site with Top Navigation
+
+This file defines the next phase of work for the repository.
+
+The FastAPI demo already exists. The goal now is to turn the demo into a **small multi-page project website** that presents the entire project clearly to visitors, reviewers, and presentation audiences.
+
+The UI layout should use a **top navigation bar** shared across all pages.
+
+---
+
+## Objective
+
+Expand the existing FastAPI + Jinja demo into a polished project website that includes:
+
+- a landing page
+- the live demo
+- a “how it works” page
+- a results page
+- an architecture page
+- a presentation page
+- a visible GitHub link
+
+The site should feel like a **portfolio/demo site**, not just a raw prediction form.
+
+This phase is about:
+- narrative
+- clarity
+- presentation readiness
+- better discoverability of project materials
+
+This phase is **not** about:
+- rewriting backend logic
+- adding a heavy frontend framework
+- adding NemoClaw yet
+
+---
+
+## Instructions for Codex
+
+You are working in the GitHub repository `willdaly/ml-group-project`.
+
+Read this file completely before making changes:
+- docs/CODEX_WEBSITE_EXPANSION_PLAN.md
+
+---
+
+## Workflow requirements
+
+1. Open a new GitHub issue for website expansion and presentation UI work.
+2. Create a new branch for that issue.
+3. Do all work on that branch.
+4. Open a pull request when complete.
+
+Do NOT work on `main`.
+
+---
+
+## UI layout decision
+
+Use **Option A**:
+- a shared **top navigation bar**
+- visible across all site pages
+- simple, clean, presentation-friendly
+
+The nav should include:
+
+- Home
+- Demo
+- How It Works
+- Results
+- Architecture
+- Presentation
+- GitHub
+
+The GitHub item should link to the repository homepage externally.
+
+---
+
+## Overall site goal
+
+If someone opens the project website, they should understand the project within 2–3 minutes without needing a spoken explanation.
+
+The site should communicate:
+
+1. What the project is
+2. Why it matters
+3. How it works
+4. What the results are
+5. How to try it
+6. Where to find the code
+7. How it connects to the presentation materials
+
+---
+
+## Required implementation tasks
+
+### 1. Add shared top navigation
+
+Create a reusable shared layout or base template for all pages.
+
+Navigation items:
+- `Home` → `/`
+- `Demo` → `/demo`
+- `How It Works` → `/how-it-works`
+- `Results` → `/results`
+- `Architecture` → `/architecture`
+- `Presentation` → `/presentation`
+- `GitHub` → external repo link
+
+Requirements:
+- keep layout simple
+- keep it visually clean
+- make it consistent across all pages
+- optimize for screenshots and live demo use
+
+---
+
+### 2. Create a landing page
+
+Route:
+- `/`
+
+This should act as the homepage and first impression of the project.
+
+Include:
+- project title
+- one-sentence pitch
+- short explanation of the project
+- a button linking to `/demo`
+- a visible GitHub link
+- short bullets for what the system does
+
+Suggested sections:
+- Problem
+- Solution
+- What you can explore on this site
+
+The homepage should feel like a project overview, not a README dump.
+
+---
+
+### 3. Keep and improve the demo page
+
+Route:
+- `/demo`
+
+Preserve the existing live demo functionality, but improve presentation.
+
+Add:
+- short instructions
+- buttons to load example inputs
+- cleaner result formatting
+- strong visual separation between:
+  - binary classification
+  - attack category
+  - confidence
+  - explanation
+  - incident summary
+
+The demo page should remain lightweight and stable.
+
+---
+
+### 4. Add a “How It Works” page
+
+Route:
+- `/how-it-works`
+
+Purpose:
+Explain the project in plain English.
+
+Include sections such as:
+- Dataset: NSL-KDD
+- Input features
+- Binary classification task
+- Multiclass attack category task
+- Models used
+- Preprocessing approach
+
+Content can be based on:
+- README
+- docs/technical_writeup.md
+- docs/presentation_notes.md
+
+Keep this page readable and concise.
+
+---
+
+### 5. Add a Results page
+
+Route:
+- `/results`
+
+Display project outputs and explain them.
+
+Include existing generated images if available, such as:
+- confusion matrices
+- ROC curves
+- feature importance
+- model comparison visuals
+
+Each visual should have:
+- a short heading
+- a sentence or two explaining what it means
+
+This page should make the project look like a finished ML system, not just a form demo.
+
+---
+
+### 6. Add an Architecture page
+
+Route:
+- `/architecture`
+
+Purpose:
+Show the engineering story.
+
+Include a simple architecture breakdown such as:
+
+`core -> services -> API -> demo`
+
+Explain:
+- why the refactor happened
+- how code is organized
+- why this makes the project reusable
+- why this sets up later agent integration
+
+Use clean sections and concise explanations.
+
+---
+
+### 7. Add a Presentation page
+
+Route:
+- `/presentation`
+
+Purpose:
+Expose the project’s presentation material in browser-readable form.
+
+Convert content from:
+- `docs/presentation_notes.md`
+
+into readable HTML sections.
+
+Keep the page:
+- slide-like
+- concise
+- easy to skim
+
+If presentation assets already exist in the repo, link to them where appropriate.
+
+---
+
+### 8. Improve content discoverability
+
+Make sure the website surfaces project materials clearly.
+
+Examples:
+- link from homepage to `/demo`
+- link from homepage to GitHub
+- link from architecture page to presentation page
+- link from results page to demo page
+- link from presentation page to GitHub or docs when helpful
+
+The site should feel connected, not like isolated pages.
+
+---
+
+### 9. Keep implementation simple
+
+Requirements:
+- use FastAPI routes
+- use Jinja templates
+- prefer a shared base template
+- do not add React/Vue/Next.js/etc.
+- do not introduce unnecessary complexity
+
+This should remain easy to run locally and easy to understand in a class project context.
+
+---
+
+### 10. Update README
+
+Add a section describing the web UI and available pages.
+
+Include:
+- how to run the app
+- what each page is for
+- how to navigate the site
+- note that the site now acts as both demo interface and presentation companion
+
+---
+
+## Recommended page structure
+
+Suggested routes:
+
+- `/` — Home / Overview
+- `/demo` — Live Demo
+- `/how-it-works` — Methods / Explanation
+- `/results` — Outputs / Metrics / Visuals
+- `/architecture` — Refactor + System Design
+- `/presentation` — Slide-style presentation content
+
+---
+
+## Design guidance
+
+Use a **clean top navbar**.
+
+Prioritize:
+- clarity
+- spacing
+- consistency
+- screenshot-friendliness
+- readability over flashiness
+
+The site should look polished enough for:
+- a class presentation
+- a portfolio walkthrough
+- a repo visitor who lands on it cold
+
+---
+
+## Constraints
+
+- Work on a new branch only
+- Keep changes incremental
+- Do not rewrite backend logic
+- Do not add NemoClaw yet
+- Do not introduce a heavy frontend stack
+- Keep the app simple, stable, and presentation-friendly
+
+---
+
+## Deliverables
+
+- new GitHub issue
+- new branch
+- shared top navigation
+- new routes and templates
+- improved homepage
+- improved demo page
+- new “How It Works” page
+- new “Results” page
+- new “Architecture” page
+- new “Presentation” page
+- updated README
+- pull request summarizing the changes
+
+---
+
+## Follow-up instruction
+
+After completing this work, the web app should function as:
+
+- live demo
+- project explainer
+- presentation companion
+- portfolio site
+
+Future work (NOT part of this task):
+- agent runtime integration
+- real-time monitoring simulation
+- async workflows
+- production deployment polish

--- a/src/api/app.py
+++ b/src/api/app.py
@@ -25,14 +25,38 @@ def create_app() -> FastAPI:
     static_dir.mkdir(exist_ok=True)
     app.mount("/static", StaticFiles(directory=str(static_dir)), name="static")
 
+    outputs_dir = PROJECT_ROOT / "outputs"
+    if outputs_dir.is_dir():
+        app.mount("/static/outputs", StaticFiles(directory=str(outputs_dir)), name="outputs")
+
     app.include_router(health.router)
     app.include_router(train.router)
     app.include_router(predict.router)
     app.include_router(report.router)
 
+    @app.get("/", response_class=HTMLResponse)
+    def home(request: Request) -> HTMLResponse:
+        return TEMPLATES.TemplateResponse(request, "home.html", {"active_page": "home"})
+
     @app.get("/demo", response_class=HTMLResponse)
     def demo(request: Request) -> HTMLResponse:
-        return TEMPLATES.TemplateResponse(request, "index.html")
+        return TEMPLATES.TemplateResponse(request, "index.html", {"active_page": "demo"})
+
+    @app.get("/how-it-works", response_class=HTMLResponse)
+    def how_it_works(request: Request) -> HTMLResponse:
+        return TEMPLATES.TemplateResponse(request, "how_it_works.html", {"active_page": "how-it-works"})
+
+    @app.get("/results", response_class=HTMLResponse)
+    def results(request: Request) -> HTMLResponse:
+        return TEMPLATES.TemplateResponse(request, "results.html", {"active_page": "results"})
+
+    @app.get("/architecture", response_class=HTMLResponse)
+    def architecture(request: Request) -> HTMLResponse:
+        return TEMPLATES.TemplateResponse(request, "architecture.html", {"active_page": "architecture"})
+
+    @app.get("/presentation", response_class=HTMLResponse)
+    def presentation(request: Request) -> HTMLResponse:
+        return TEMPLATES.TemplateResponse(request, "presentation.html", {"active_page": "presentation"})
 
     return app
 

--- a/src/api/app.py
+++ b/src/api/app.py
@@ -23,11 +23,12 @@ def create_app() -> FastAPI:
     )
     static_dir = PROJECT_ROOT / "static"
     static_dir.mkdir(exist_ok=True)
-    app.mount("/static", StaticFiles(directory=str(static_dir)), name="static")
 
     outputs_dir = PROJECT_ROOT / "outputs"
     if outputs_dir.is_dir():
         app.mount("/static/outputs", StaticFiles(directory=str(outputs_dir)), name="outputs")
+
+    app.mount("/static", StaticFiles(directory=str(static_dir)), name="static")
 
     app.include_router(health.router)
     app.include_router(train.router)

--- a/templates/architecture.html
+++ b/templates/architecture.html
@@ -1,0 +1,89 @@
+{% extends "base.html" %}
+{% block title %}Architecture — NSL-KDD Detection Engine{% endblock %}
+
+{% block extra_css %}
+      .arch-diagram {
+        font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+        font-size: 0.88rem;
+        background: #ffffff;
+        border: 1px solid var(--line);
+        border-radius: 8px;
+        padding: 20px 24px;
+        line-height: 1.7;
+        overflow-x: auto;
+        white-space: pre;
+        color: var(--ink);
+      }
+{% endblock %}
+
+{% block content %}
+<h1>Architecture</h1>
+<p class="subtitle">How the codebase is organized into a reusable ML core, service layer, and API.</p>
+
+<h2>Design Goals</h2>
+<div class="card">
+  <p>The original project was a compact class-submission pipeline centered around <code>main.py</code>. The refactor introduced cleaner boundaries so the ML logic can be reused independently of the HTTP layer:</p>
+  <ul>
+    <li><strong>Core</strong> — pure data loading, feature engineering, model training, inference, and explanations</li>
+    <li><strong>Services</strong> — application workflows that coordinate core modules</li>
+    <li><strong>API</strong> — FastAPI routes, schemas, and the browser demo</li>
+  </ul>
+  <p>Legacy modules remain as compatibility shims so existing tests and the CLI continue to work.</p>
+</div>
+
+<h2>Module Layout</h2>
+<div class="arch-diagram">src/
+  core/
+    data_loader.py    dataset resolution and NSL-KDD frame loading
+    features.py       target mapping, preprocessing, feature-frame normalization
+    models.py         scikit-learn model factories and joblib persistence
+    train.py          training, evaluation, visualization, saved artifacts
+    infer.py          single and batch inference helpers
+    explain.py        concise analyst-style explanation text
+  services/
+    training_service.py     full training workflow
+    detection_service.py    model loading + predict / predict_many
+    reporting_service.py    incident summary aggregation
+  api/
+    app.py            FastAPI factory and page routes
+    schemas.py        request and response models
+    routes/           health, train, predict, and report endpoints</div>
+
+<h2>Request Flow</h2>
+<div class="card">
+  <h3>Training</h3>
+  <p><code>main.py</code> or <code>POST /train</code> &rarr; TrainingService &rarr; load data &rarr; EDA &rarr; train binary models &rarr; train multiclass model &rarr; save artifacts</p>
+
+  <h3>Prediction</h3>
+  <p><code>POST /predict</code> &rarr; DetectionService &rarr; load models &rarr; normalize features &rarr; score binary &rarr; score multiclass &rarr; explain &rarr; return result</p>
+
+  <h3>Reporting</h3>
+  <p><code>POST /report/incidents</code> &rarr; accept predictions or raw records &rarr; aggregate counts &rarr; summarize high-confidence attacks</p>
+</div>
+
+<h2>Saved Artifacts</h2>
+<div class="card">
+  <ul>
+    <li><code>models/binary_model.joblib</code> — best binary classifier pipeline</li>
+    <li><code>models/multiclass_model.joblib</code> — attack category classifier</li>
+    <li><code>models/metadata.json</code> — training run metadata</li>
+    <li><code>outputs/</code> — EDA charts, metrics JSON, confusion matrices, ROC curves</li>
+  </ul>
+</div>
+
+<h2>Design Boundaries</h2>
+<div class="card">
+  <ul>
+    <li>Core modules do not import FastAPI</li>
+    <li>Services coordinate workflows but do not define HTTP schemas</li>
+    <li>API routes validate requests, call services, and return response models</li>
+    <li>Compatibility shims keep old imports stable for tests and notebooks</li>
+  </ul>
+</div>
+
+<h2>Future Direction</h2>
+<div class="card">
+  <p>The clean separation of core, services, and API makes it straightforward to wrap the detection and reporting services in an autonomous agent runtime without changing the ML logic.</p>
+  <p><a href="/presentation">See the presentation &rarr;</a></p>
+</div>
+{% endblock %}

--- a/templates/base.html
+++ b/templates/base.html
@@ -1,0 +1,180 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>{% block title %}NSL-KDD Detection Engine{% endblock %}</title>
+    <style>
+      :root {
+        color-scheme: light;
+        font-family: Arial, Helvetica, sans-serif;
+        --ink: #17202a;
+        --muted: #52616b;
+        --line: #c8d1d9;
+        --accent: #0f766e;
+        --accent-light: #e6f5f3;
+        --alert: #b42318;
+        --alert-light: #fef2f2;
+        --safe: #16a34a;
+        --safe-light: #f0fdf4;
+        --paper: #f7f9fb;
+      }
+
+      * { box-sizing: border-box; }
+
+      body {
+        margin: 0;
+        color: var(--ink);
+        background: var(--paper);
+      }
+
+      /* ── Top navigation ── */
+      nav {
+        display: flex;
+        align-items: center;
+        gap: 6px;
+        padding: 0 24px;
+        height: 52px;
+        background: #ffffff;
+        border-bottom: 1px solid var(--line);
+        overflow-x: auto;
+      }
+
+      nav .brand {
+        font-weight: 800;
+        font-size: 0.95rem;
+        color: var(--accent);
+        text-decoration: none;
+        white-space: nowrap;
+        margin-right: 12px;
+      }
+
+      nav a {
+        font-size: 0.85rem;
+        font-weight: 600;
+        color: var(--muted);
+        text-decoration: none;
+        padding: 6px 10px;
+        border-radius: 6px;
+        white-space: nowrap;
+        transition: background 0.15s, color 0.15s;
+      }
+
+      nav a:hover { background: var(--accent-light); color: var(--accent); }
+      nav a.active { background: var(--accent-light); color: var(--accent); }
+
+      nav .spacer { flex: 1; }
+
+      nav a.external {
+        margin-left: 4px;
+        border: 1px solid var(--line);
+        border-radius: 6px;
+      }
+
+      /* ── Page content ── */
+      .page {
+        width: min(980px, calc(100% - 32px));
+        margin: 0 auto;
+        padding: 32px 0 64px;
+      }
+
+      h1 { margin: 0 0 4px; font-size: 2rem; }
+      h2 { margin: 32px 0 12px; font-size: 1.35rem; }
+      h3 { margin: 24px 0 8px; font-size: 1.1rem; }
+
+      p, li {
+        color: var(--muted);
+        line-height: 1.6;
+        font-size: 0.95rem;
+      }
+
+      .subtitle {
+        color: var(--muted);
+        line-height: 1.5;
+        margin: 0 0 20px;
+        font-size: 1rem;
+      }
+
+      a { color: var(--accent); }
+
+      /* ── Shared components ── */
+      .card {
+        border: 1px solid var(--line);
+        border-radius: 10px;
+        background: #ffffff;
+        padding: 20px 24px;
+        margin-bottom: 16px;
+      }
+
+      .card h3 { margin-top: 0; }
+
+      .btn {
+        display: inline-block;
+        border: 0;
+        border-radius: 8px;
+        padding: 12px 20px;
+        color: #ffffff;
+        background: var(--accent);
+        font-weight: 700;
+        font-size: 0.95rem;
+        text-decoration: none;
+        cursor: pointer;
+      }
+
+      .btn:hover { opacity: 0.9; color: #ffffff; }
+
+      .btn.secondary {
+        background: transparent;
+        color: var(--accent);
+        border: 1px solid var(--accent);
+      }
+
+      .badge {
+        display: inline-block;
+        padding: 3px 10px;
+        border-radius: 20px;
+        font-size: 0.75rem;
+        font-weight: 700;
+        text-transform: uppercase;
+        letter-spacing: 0.04em;
+      }
+
+      .badge.normal { background: var(--safe-light); color: var(--safe); }
+      .badge.attack { background: var(--alert-light); color: var(--alert); }
+
+      img.chart {
+        width: 100%;
+        max-width: 720px;
+        border: 1px solid var(--line);
+        border-radius: 8px;
+        margin: 8px 0 16px;
+      }
+
+      code {
+        background: #edf2f7;
+        padding: 2px 6px;
+        border-radius: 4px;
+        font-size: 0.88rem;
+      }
+
+      {% block extra_css %}{% endblock %}
+    </style>
+  </head>
+  <body>
+    <nav>
+      <a class="brand" href="/">NSL-KDD Engine</a>
+      <a href="/" {% if active_page == "home" %}class="active"{% endif %}>Home</a>
+      <a href="/demo" {% if active_page == "demo" %}class="active"{% endif %}>Demo</a>
+      <a href="/how-it-works" {% if active_page == "how-it-works" %}class="active"{% endif %}>How It Works</a>
+      <a href="/results" {% if active_page == "results" %}class="active"{% endif %}>Results</a>
+      <a href="/architecture" {% if active_page == "architecture" %}class="active"{% endif %}>Architecture</a>
+      <a href="/presentation" {% if active_page == "presentation" %}class="active"{% endif %}>Presentation</a>
+      <span class="spacer"></span>
+      <a class="external" href="https://github.com/willdaly/ml-group-project" target="_blank" rel="noopener">GitHub &nearr;</a>
+    </nav>
+
+    <div class="page">
+      {% block content %}{% endblock %}
+    </div>
+  </body>
+</html>

--- a/templates/home.html
+++ b/templates/home.html
@@ -1,0 +1,48 @@
+{% extends "base.html" %}
+{% block title %}NSL-KDD Cybersecurity Detection Engine{% endblock %}
+
+{% block content %}
+<h1>NSL-KDD Cybersecurity Detection Engine</h1>
+<p class="subtitle">A machine-learning system that classifies network traffic as normal or attack, identifies the attack category, and explains the result.</p>
+
+<div style="margin: 24px 0;">
+  <a class="btn" href="/demo">Try the Live Demo &rarr;</a>
+  <a class="btn secondary" href="https://github.com/willdaly/ml-group-project" target="_blank" rel="noopener" style="margin-left: 8px;">View on GitHub</a>
+</div>
+
+<h2>The Problem</h2>
+<p>Network defenders need fast, automated ways to separate normal traffic from suspicious activity. Manual inspection doesn't scale when thousands of connections arrive every second.</p>
+
+<h2>Our Solution</h2>
+<p>We built a supervised learning pipeline on the <strong>NSL-KDD</strong> benchmark dataset that:</p>
+<ul>
+  <li><strong>Binary classification</strong> — separates normal traffic from attacks</li>
+  <li><strong>Multiclass classification</strong> — identifies the attack category (DoS, Probe, R2L, U2R)</li>
+  <li><strong>Confidence scoring</strong> — reports how certain the model is</li>
+  <li><strong>Analyst explanations</strong> — highlights which features drove the prediction</li>
+</ul>
+
+<h2>Explore This Site</h2>
+<div style="display: grid; grid-template-columns: repeat(auto-fit, minmax(280px, 1fr)); gap: 16px; margin-top: 12px;">
+  <div class="card">
+    <h3><a href="/demo">Live Demo</a></h3>
+    <p>Score a network connection record and see the classification, confidence, and explanation in real time.</p>
+  </div>
+  <div class="card">
+    <h3><a href="/how-it-works">How It Works</a></h3>
+    <p>Learn about the dataset, features, models, and preprocessing approach.</p>
+  </div>
+  <div class="card">
+    <h3><a href="/results">Results</a></h3>
+    <p>View confusion matrices, ROC curves, feature importance, and model comparison charts.</p>
+  </div>
+  <div class="card">
+    <h3><a href="/architecture">Architecture</a></h3>
+    <p>See how the codebase is organized into a reusable ML core, service layer, and API.</p>
+  </div>
+  <div class="card">
+    <h3><a href="/presentation">Presentation</a></h3>
+    <p>Browse the project's presentation material in a slide-style format.</p>
+  </div>
+</div>
+{% endblock %}

--- a/templates/how_it_works.html
+++ b/templates/how_it_works.html
@@ -1,0 +1,76 @@
+{% extends "base.html" %}
+{% block title %}How It Works — NSL-KDD Detection Engine{% endblock %}
+
+{% block content %}
+<h1>How It Works</h1>
+<p class="subtitle">An overview of the dataset, features, models, and preprocessing behind the detection engine.</p>
+
+<h2>Dataset: NSL-KDD</h2>
+<div class="card">
+  <p>The project uses the <strong>NSL-KDD</strong> dataset, a refined benchmark derived from KDD Cup 1999 network intrusion data. Each row describes a single network connection with protocol details, byte counts, error rates, host-level statistics, and a label.</p>
+  <p>The dataset includes two files: <code>KDDTrain+.txt</code> (training) and <code>KDDTest+.txt</code> (evaluation), stored locally under <code>data/nsl-kdd/</code> so the project runs fully offline.</p>
+</div>
+
+<h2>Input Features</h2>
+<div class="card">
+  <p>Each connection record contains fields such as:</p>
+  <ul>
+    <li><strong>Protocol type</strong> — tcp, udp, icmp</li>
+    <li><strong>Service</strong> — http, ftp, smtp, private, etc.</li>
+    <li><strong>Flag</strong> — connection status (SF, S0, REJ, etc.)</li>
+    <li><strong>Byte counts</strong> — src_bytes, dst_bytes</li>
+    <li><strong>Error rates</strong> — serror_rate, srv_serror_rate, dst_host_serror_rate</li>
+    <li><strong>Connection counts</strong> — count, srv_count, dst_host_count</li>
+    <li><strong>Login indicators</strong> — num_failed_logins, logged_in, root_shell</li>
+  </ul>
+  <p>Categorical fields are one-hot encoded. Numeric fields are scaled and imputed.</p>
+</div>
+
+<h2>Binary Classification</h2>
+<div class="card">
+  <p>The first task separates traffic into two classes: <span class="badge normal">normal</span> and <span class="badge attack">attack</span>.</p>
+  <p>Three models are trained and evaluated:</p>
+  <ul>
+    <li>Logistic Regression</li>
+    <li>Random Forest</li>
+    <li>Gradient Boosting</li>
+  </ul>
+  <p>The best model is selected by <strong>F1 score</strong> on the test set.</p>
+</div>
+
+<h2>Multiclass Attack Categories</h2>
+<div class="card">
+  <p>Once traffic is flagged as an attack, a second Random Forest model classifies it into one of five NSL-KDD categories:</p>
+  <ul>
+    <li><strong>DoS</strong> — Denial of Service</li>
+    <li><strong>Probe</strong> — Surveillance / scanning</li>
+    <li><strong>R2L</strong> — Remote to Local unauthorized access</li>
+    <li><strong>U2R</strong> — User to Root privilege escalation</li>
+    <li><strong>Normal</strong> — Benign traffic</li>
+  </ul>
+</div>
+
+<h2>Preprocessing</h2>
+<div class="card">
+  <p>The pipeline applies:</p>
+  <ul>
+    <li><strong>One-hot encoding</strong> for categorical features (protocol_type, service, flag)</li>
+    <li><strong>Median imputation</strong> for missing numeric values</li>
+    <li><strong>Standard scaling</strong> for numeric features</li>
+    <li><strong>Safe defaults</strong> for missing columns at inference time</li>
+  </ul>
+  <p>This ensures the demo can score compact JSON inputs without requiring all 41 original NSL-KDD columns.</p>
+</div>
+
+<h2>Inference &amp; Explanation</h2>
+<div class="card">
+  <p>Each prediction returns:</p>
+  <ul>
+    <li><strong>Binary class</strong> — normal or attack</li>
+    <li><strong>Attack category</strong> — when classified as an attack</li>
+    <li><strong>Confidence score</strong> — from <code>predict_proba</code> when available</li>
+    <li><strong>Analyst explanation</strong> — a plain-English summary of which features contributed to the classification</li>
+  </ul>
+  <p><a href="/demo">Try it live &rarr;</a></p>
+</div>
+{% endblock %}

--- a/templates/index.html
+++ b/templates/index.html
@@ -1,46 +1,7 @@
-<!doctype html>
-<html lang="en">
-  <head>
-    <meta charset="utf-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1">
-    <title>NSL-KDD Detection Demo</title>
-    <style>
-      :root {
-        color-scheme: light;
-        font-family: Arial, Helvetica, sans-serif;
-        --ink: #17202a;
-        --muted: #52616b;
-        --line: #c8d1d9;
-        --accent: #0f766e;
-        --accent-light: #e6f5f3;
-        --alert: #b42318;
-        --alert-light: #fef2f2;
-        --safe: #16a34a;
-        --safe-light: #f0fdf4;
-        --paper: #f7f9fb;
-      }
+{% extends "base.html" %}
+{% block title %}Live Demo — NSL-KDD Detection Engine{% endblock %}
 
-      body {
-        margin: 0;
-        color: var(--ink);
-        background: var(--paper);
-      }
-
-      main {
-        width: min(980px, calc(100% - 32px));
-        margin: 0 auto;
-        padding: 32px 0;
-      }
-
-      h1 { margin: 0 0 4px; font-size: 2rem; }
-      h2 { margin: 28px 0 12px; font-size: 1.25rem; }
-
-      .subtitle {
-        color: var(--muted);
-        line-height: 1.5;
-        margin: 0 0 16px;
-      }
-
+{% block extra_css %}
       textarea {
         width: 100%;
         min-height: 240px;
@@ -60,25 +21,6 @@
         margin: 12px 0 0;
       }
 
-      button {
-        border: 0;
-        border-radius: 8px;
-        padding: 10px 16px;
-        color: #ffffff;
-        background: var(--accent);
-        font-weight: 700;
-        font-size: 0.9rem;
-        cursor: pointer;
-      }
-
-      button:hover { opacity: 0.9; }
-
-      button.secondary {
-        background: transparent;
-        color: var(--accent);
-        border: 1px solid var(--accent);
-      }
-
       .status {
         margin: 16px 0;
         padding: 10px 12px;
@@ -89,7 +31,6 @@
 
       .error { border-left-color: var(--alert); }
 
-      /* Result card */
       .result-card {
         border: 1px solid var(--line);
         border-radius: 10px;
@@ -112,32 +53,10 @@
         font-size: 1.1rem;
       }
 
-      .result-header.normal {
-        background: var(--safe-light);
-        color: var(--safe);
-      }
+      .result-header.normal { background: var(--safe-light); color: var(--safe); }
+      .result-header.attack { background: var(--alert-light); color: var(--alert); }
 
-      .result-header.attack {
-        background: var(--alert-light);
-        color: var(--alert);
-      }
-
-      .badge {
-        display: inline-block;
-        padding: 3px 10px;
-        border-radius: 20px;
-        font-size: 0.75rem;
-        font-weight: 700;
-        text-transform: uppercase;
-        letter-spacing: 0.04em;
-      }
-
-      .badge.normal { background: var(--safe-light); color: var(--safe); }
-      .badge.attack { background: var(--alert-light); color: var(--alert); }
-
-      .result-body {
-        padding: 16px 20px;
-      }
+      .result-body { padding: 16px 20px; }
 
       .result-row {
         display: flex;
@@ -148,15 +67,8 @@
 
       .result-row:last-child { border-bottom: none; }
 
-      .result-label {
-        color: var(--muted);
-        font-size: 0.85rem;
-      }
-
-      .result-value {
-        font-weight: 600;
-        font-size: 0.95rem;
-      }
+      .result-label { color: var(--muted); font-size: 0.85rem; }
+      .result-value { font-weight: 600; font-size: 0.95rem; }
 
       .explanation {
         margin-top: 12px;
@@ -185,10 +97,26 @@
 
       .confidence-fill.normal { background: var(--safe); }
       .confidence-fill.attack { background: var(--alert); }
-    </style>
-  </head>
-  <body>
-    <main>
+
+      button {
+        border: 0;
+        border-radius: 8px;
+        padding: 10px 16px;
+        color: #ffffff;
+        background: var(--accent);
+        font-weight: 700;
+        font-size: 0.9rem;
+        cursor: pointer;
+      }
+      button:hover { opacity: 0.9; }
+      button.secondary {
+        background: transparent;
+        color: var(--accent);
+        border: 1px solid var(--accent);
+      }
+{% endblock %}
+
+{% block content %}
       <h1>NSL-KDD Detection Demo</h1>
       <p class="subtitle">Score a network connection record with the saved binary and multiclass models.</p>
 
@@ -340,6 +268,5 @@
 
       refreshHealth();
     </script>
-  </body>
-</html>
+{% endblock %}
 

--- a/templates/presentation.html
+++ b/templates/presentation.html
@@ -1,0 +1,133 @@
+{% extends "base.html" %}
+{% block title %}Presentation — NSL-KDD Detection Engine{% endblock %}
+
+{% block extra_css %}
+      .slide {
+        border: 1px solid var(--line);
+        border-radius: 10px;
+        background: #ffffff;
+        padding: 28px 32px;
+        margin-bottom: 20px;
+      }
+      .slide h2 {
+        margin-top: 0;
+        font-size: 1.3rem;
+        color: var(--accent);
+      }
+      .slide-number {
+        display: inline-block;
+        background: var(--accent-light);
+        color: var(--accent);
+        font-weight: 700;
+        font-size: 0.75rem;
+        padding: 2px 8px;
+        border-radius: 10px;
+        margin-bottom: 8px;
+      }
+{% endblock %}
+
+{% block content %}
+<h1>Presentation</h1>
+<p class="subtitle">Slide-style overview of the project, suitable for a 10–15 minute walkthrough.</p>
+
+<div class="slide">
+  <span class="slide-number">1</span>
+  <h2>NSL-KDD Cybersecurity Detection Engine</h2>
+  <p>A class ML pipeline refactored into a reusable intrusion-detection engine with saved models, inference services, incident reports, and a browser demo.</p>
+</div>
+
+<div class="slide">
+  <span class="slide-number">2</span>
+  <h2>The Problem</h2>
+  <p>Network defenders need fast ways to separate normal traffic from suspicious activity. Manual inspection doesn't scale when thousands of connections arrive every second.</p>
+</div>
+
+<div class="slide">
+  <span class="slide-number">3</span>
+  <h2>Dataset: NSL-KDD</h2>
+  <ul>
+    <li>Tabular network connection records</li>
+    <li>Protocol, service, byte counts, error rates, host-level statistics</li>
+    <li>Labels: normal traffic and multiple attack types</li>
+    <li>Categories: DoS, Probe, R2L, U2R, Normal</li>
+  </ul>
+</div>
+
+<div class="slide">
+  <span class="slide-number">4</span>
+  <h2>Modeling Approach</h2>
+  <p><strong>Binary task:</strong> normal vs attack — Logistic Regression, Random Forest, Gradient Boosting. Best selected by F1.</p>
+  <p><strong>Multiclass task:</strong> attack category — Random Forest over five categories.</p>
+  <p><strong>Preprocessing:</strong> one-hot encoding for categoricals, median imputation and scaling for numerics.</p>
+</div>
+
+<div class="slide">
+  <span class="slide-number">5</span>
+  <h2>Architecture</h2>
+  <ul>
+    <li><strong>Core</strong> — data loading, feature engineering, training, inference, explanations</li>
+    <li><strong>Services</strong> — training workflow, detection service, incident reporting</li>
+    <li><strong>API</strong> — FastAPI routes, schemas, browser demo</li>
+  </ul>
+  <p><a href="/architecture">See full architecture &rarr;</a></p>
+</div>
+
+<div class="slide">
+  <span class="slide-number">6</span>
+  <h2>Live Demo</h2>
+  <ol>
+    <li>Start server with <code>uvicorn src.api.app:app --reload</code></li>
+    <li>Open <code>/demo</code></li>
+    <li>Load benign example &rarr; score &rarr; see "Normal Traffic"</li>
+    <li>Load attack example &rarr; score &rarr; see "Attack Detected" with category and explanation</li>
+    <li>Call <code>/report/incidents</code> to summarize predictions</li>
+  </ol>
+  <p><a href="/demo">Open demo &rarr;</a></p>
+</div>
+
+<div class="slide">
+  <span class="slide-number">7</span>
+  <h2>Results</h2>
+  <ul>
+    <li>Binary confusion matrices and ROC curves</li>
+    <li>Multiclass confusion matrix</li>
+    <li>Feature importance rankings</li>
+    <li>Scores depend on NSL-KDD train/test split and selected model</li>
+  </ul>
+  <p><a href="/results">View charts &rarr;</a></p>
+</div>
+
+<div class="slide">
+  <span class="slide-number">8</span>
+  <h2>Limitations</h2>
+  <ul>
+    <li>NSL-KDD is a benchmark, not modern production traffic</li>
+    <li>Explanations are concise analyst summaries, not full causal attributions</li>
+    <li>Training endpoint is synchronous (demo use only)</li>
+    <li>Models are classical scikit-learn baselines for class-project clarity</li>
+  </ul>
+</div>
+
+<div class="slide">
+  <span class="slide-number">9</span>
+  <h2>Future Work</h2>
+  <ul>
+    <li>Richer explanations (permutation importance, SHAP)</li>
+    <li>Uploaded CSV batch scoring</li>
+    <li>Asynchronous training jobs and run history</li>
+    <li>Model cards with dataset provenance and caveats</li>
+    <li>Autonomous agent wrapper around the service layer</li>
+  </ul>
+</div>
+
+<div class="slide">
+  <span class="slide-number">10</span>
+  <h2>Thank You</h2>
+  <p>Explore the project:</p>
+  <ul>
+    <li><a href="/demo">Live Demo</a></li>
+    <li><a href="/results">Results &amp; Charts</a></li>
+    <li><a href="https://github.com/willdaly/ml-group-project" target="_blank" rel="noopener">GitHub Repository</a></li>
+  </ul>
+</div>
+{% endblock %}

--- a/templates/results.html
+++ b/templates/results.html
@@ -1,0 +1,51 @@
+{% extends "base.html" %}
+{% block title %}Results — NSL-KDD Detection Engine{% endblock %}
+
+{% block content %}
+<h1>Results</h1>
+<p class="subtitle">Model evaluation outputs generated from the NSL-KDD training pipeline.</p>
+
+<h2>Model Comparison</h2>
+<div class="card">
+  <p>Accuracy, precision, recall, and F1 scores across binary classifiers. The best model is selected by F1.</p>
+  <img class="chart" src="/static/outputs/model_comparison.png" alt="Model comparison bar chart">
+</div>
+
+<h2>Confusion Matrices</h2>
+<div class="card">
+  <p>Binary classification confusion matrices for each model showing true/false positives and negatives.</p>
+  <img class="chart" src="/static/outputs/confusion_matrices.png" alt="Binary confusion matrices">
+</div>
+
+<h2>ROC Curves</h2>
+<div class="card">
+  <p>Receiver Operating Characteristic curves showing the trade-off between true positive rate and false positive rate.</p>
+  <img class="chart" src="/static/outputs/roc_curves.png" alt="ROC curves">
+</div>
+
+<h2>Multiclass Confusion Matrix</h2>
+<div class="card">
+  <p>Attack category classification performance across all five NSL-KDD categories.</p>
+  <img class="chart" src="/static/outputs/multiclass_confusion_matrix.png" alt="Multiclass confusion matrix">
+</div>
+
+<h2>Feature Importance</h2>
+<div class="card">
+  <p>Top features driving the binary classification decision, ranked by importance in the best model.</p>
+  <img class="chart" src="/static/outputs/feature_importance.png" alt="Feature importance chart">
+</div>
+
+<h2>Label Distribution</h2>
+<div class="card">
+  <p>Distribution of normal vs attack labels in the training data.</p>
+  <img class="chart" src="/static/outputs/label_distribution.png" alt="Label distribution">
+</div>
+
+<h2>Attack Category Distribution</h2>
+<div class="card">
+  <p>Breakdown of attack types across the dataset.</p>
+  <img class="chart" src="/static/outputs/attack_category_distribution.png" alt="Attack category distribution">
+</div>
+
+<p style="margin-top: 24px;"><a href="/demo">Try the live demo &rarr;</a></p>
+{% endblock %}


### PR DESCRIPTION
## Summary

Turns the FastAPI demo into a multi-page project website with a shared top navigation bar. Closes #7.

### New Pages

| Page | Route | Template |
|------|-------|----------|
| Home | `/` | home.html |
| Demo | `/demo` | index.html (migrated to base) |
| How It Works | `/how-it-works` | how_it_works.html |
| Results | `/results` | results.html |
| Architecture | `/architecture` | architecture.html |
| Presentation | `/presentation` | presentation.html |

### Implementation

- **base.html** — shared Jinja2 base template with top nav bar, active page highlighting, CSS variables, and shared components
- **Outputs mounted** at `/static/outputs` so charts render on the Results page
- **No backend changes** — only new routes and templates
- **README** updated with Project Website section

### Testing

All 10 existing tests pass. No architecture or ML logic changes.